### PR TITLE
Remove dynamic allocation of format string - replace with named fields

### DIFF
--- a/include/progressbar.h
+++ b/include/progressbar.h
@@ -41,7 +41,12 @@ typedef struct _progressbar_t
   char *progress_str;
   /// characters for the beginning, filling and end of the
   /// progressbar. E.g. |###    | has |#|
-  char *format;
+  struct {
+    char begin;
+    char fill;
+    char end;
+  } format;
+
   /// number of characters printed on last output
   int last_printed;
   /// terminal information


### PR DESCRIPTION
There is no need to use dynamic allocation for the format string - we can store the 3 chars instead. Using a nested struct keeps the field names simple imo.