### PR TITLE
Fixed segfault when terminal small enough to cause label cutoff and refactored drawing code

### DIFF
--- a/include/progressbar.h
+++ b/include/progressbar.h
@@ -28,15 +28,12 @@ typedef struct _progressbar_t
   /// current value
   unsigned long value;
 
-  /// maximum number of steps
-  unsigned int steps;
-  /// current step
-  unsigned int step;
-
   /// time progressbar was started
   time_t start;
+
   /// label
   const char *label;
+
   /// characters for the beginning, filling and end of the
   /// progressbar. E.g. |###    | has |#|
   struct {
@@ -44,19 +41,31 @@ typedef struct _progressbar_t
     char fill;
     char end;
   } format;
-
-  /// terminal information
-  char * termtype;
 } progressbar;
 
-/// Create a new progressbar with the specified label and # of steps
-progressbar *progressbar_new(char *label, unsigned long max);
+/// Create a new progressbar with the specified label and number of steps.
+///
+/// @param label The label that will prefix the progressbar.
+/// @param max The number of times the progressbar must be incremented before it is considered complete,
+///            or, in other words, the number of tasks that this progressbar is tracking.
+///
+/// @return A progressbar configured with the provided arguments. Note that the user is responsible for disposing
+///         of the progressbar via progressbar_finish when finished with the object.
+progressbar *progressbar_new(const char *label, unsigned long max);
 
-/// Create a new progressbar with the specified label, # of steps, and format string.
-/// Format strings are three-character strings indicating the left bar, fill, and
-/// right bar (in that order). For example, "(.)" would result in a progress bar
-/// like "(...........)".
-progressbar *progressbar_new_with_format(char *label, unsigned long max, const char *format);
+/// Create a new progressbar with the specified label, number of steps, and format string.
+///
+/// @param label The label that will prefix the progressbar.
+/// @param max The number of times the progressbar must be incremented before it is considered complete,
+///            or, in other words, the number of tasks that this progressbar is tracking.
+/// @param format The format of the progressbar. The string provided must be three characters, and it will
+///               be interpretted with the first character as the left border of the bar, the second
+///               character of the bar and the third character as the right border of the bar. For example,
+///               "<->" would result in a bar formatted like "<------     >".
+///
+/// @return A progressbar configured with the provided arguments. Note that the user is responsible for disposing
+///         of the progressbar via progressbar_finish when finished with the object.
+progressbar *progressbar_new_with_format(const char *label, unsigned long max, const char *format);
 
 /// Free an existing progress bar. Don't call this directly; call *progressbar_finish* instead.
 void progressbar_free(progressbar *bar);
@@ -67,16 +76,13 @@ void progressbar_inc(progressbar *bar);
 /// Set the current status on the given progressbar.
 void progressbar_update(progressbar *bar, unsigned long value);
 
-/// Change the current label
+/// Set the label of the progressbar. Note that no rendering is done. The label is simply set so that the next
+/// rendering will use the new label. To immediately see the new label, call progressbar_draw.
 /// Does not update display or copy the label
-void progressbar_update_label(progressbar *bar, char *label);
+void progressbar_update_label(progressbar *bar, const char *label);
 
 /// Finalize (and free!) a progressbar. Call this when you're done, or if you break out
 /// partway through.
 void progressbar_finish(progressbar *bar);
-
-/// Draw a progressbar to the screen with the specified time display. Don't call this directly,
-/// as it's called internally by *progressbar_inc*.
-void progressbar_draw(const progressbar *bar, unsigned int time);
 
 #endif


### PR DESCRIPTION
There is currently a bug in progressbar where it will crash if resized too small when using a label that is a string literal (and thus modifiable memory). Really though, even though this bug is caused by using a string literal for the label, it shows a problem with how the progressbar views the label string. It either needs to take ownership of it, meaning that is responsible for memory management of it once the user has provided it (which requires the user to pass a malloc'd string and not a literal...), or it needs to leave the memory management of the label up to the caller.

The second approach seems more reasonable so that we can avoid unnecessary copying of strings or putting a burden on the user, but this means that the amount of the string that should be rendered must be either computed or stored in the bar. In other words, we can't `str[idx] = 0` a string we don't own.

To this end, I started reworking how the progressbar handles rendering of the label, and I might have gotten a bit carried away and ended up refactoring most of the drawing code. 

Technical changes:

* `progressbar` no longer modifies the given label at all. Also, it is now explicitly documented that the user is responsible for ensuring that the label continues to exist throughout the existence of the progressbar.
* `progressbar` no longer stores the terminal type. That's an implementation detail of rendering, and `struct progressbar` is responsible for modeling a progressbar.
* `step` and `steps` are no longer stored on the `progressbar`. Again, they're artifacts of rendering, and they do not belong in the `progressbar` object. They are now calculated during rendering.
* Some `#define` macros were converted to be `enum`-style constants. This allows for better typesafety and a higher likelihood that the symbols will have names in a debugger.
* The format of the ETA string along with some magic constants (amount of whitespace, bar border width, etc) have been converted to constants.
* `progressbar_draw` is no longer exposed in the header or exported in the source. **This is a backward compatibility breaking change**. Anyone who used the `progressbar_draw` method will have to alter their code to be compatible with new versions of `progressbar` if this PR is accepted. However, the method does not make much sense to call directly anyway, and it's documented as internal, so I'm hoping this is acceptable.
* `progressbar_draw` no longer takes in an ETA but rather calculates it itself. This allowed for removing a lot of replicated code at various calling sites to calculate elapsed time, items remaining, etc.
* The actual bar component of the `progressbar` no longer requires a buffer to render. Instead, it is rendered straight to `stderr`.
* Width calculations have been broken out to be a bit clearer and more contained.

Improvements in functionality:

* The bar no longer segfaults when sized below a certain width.
* The bar now resizes instead of sticking to the size of the terminal when the bar first rendered. Currently it only resizes when the bar is redrawn, but it should be trivial to add a listener for the terminal resizing and redraw appropriately if someone were so inclined.
* The bar is now the full width of the terminal instead of having two trailing blank spaces (I believe there was a bug with the width calculations where the ETA was given more space than it needed).