### PR TITLE
check if malloc failed and return NULL

### DIFF
--- a/lib/statusbar.c
+++ b/lib/statusbar.c
@@ -14,10 +14,19 @@
 statusbar *statusbar_new_with_format(const char *label, const char *format)
 {
   statusbar *new = malloc(sizeof(statusbar));
+  if(new == NULL) {
+    return NULL;
+  }
+
   new->label = label;
   new->start_time = time(0);
   new->format_length = strlen(format);
   new->format = malloc( sizeof(char) * (new->format_length + 1) );
+  if(new->format == NULL) {
+    free(new);
+    return NULL;
+  }
+
   strncpy(new->format, format, new->format_length);
   new->format_index = 0;
   new->last_printed = 0;


### PR DESCRIPTION
Though it is unlikely that malloc will fail, it is good practice to check for failure and return NULL. If allocation of new->format fails, we have to free new in order to avoid a memory leak.