### PR TITLE
Add CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(ProgressBar)
+
+include_directories(include)
+
+add_library(progressbar lib/progressbar.c)
+add_library(statusbar lib/statusbar.c)
+
+add_executable(demo test/demo.c)
+target_link_libraries(demo progressbar statusbar ncurses)


### PR DESCRIPTION
I included this in a larger C++ project where I use CMake for building so I created a CMakeLists.txt which builds the progressbar and statusbar libraries.

Using it from my project then needs two lines in my CMakeLists.txt:
add_subdirectory(progressbar)
target_link_libraries(myprogram progressbar)