### PR TITLE
Fix README syntax highlighting

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -10,13 +10,15 @@ progressbar is implemented in pure C99, but using a vaguely object-oriented conv
 
 Example usage:
 
-    progressbar *progress = progressbar_new("Loading",100);
-    for(int i=0; i < 100; i++)
-    {
-      // Do some stuff
-      progressbar_inc(progress);
-    }
-    progressbar_finish(progress);
+```c
+progressbar *progress = progressbar_new("Loading",100);
+for(int i=0; i < 100; i++)
+{
+  // Do some stuff
+  progressbar_inc(progress);
+}
+progressbar_finish(progress);
+```
 
 Example output (from `progressbar_demo.c`):
 
@@ -43,6 +45,8 @@ so feel free to take it and run with it. Details can be found in the `LICENSE` f
 
 If progressbar fails to build because `termcap.h` isn't found, you're probably missing the ncurses dev libraries.
 
-    gcc -c -std=c99 -Iinclude lib/progressbar.c
-    lib/progressbar.c:13:45: fatal error: termcap.h: No such file or directory
-    compilation terminated.
+```
+gcc -c -std=c99 -Iinclude lib/progressbar.c
+lib/progressbar.c:13:45: fatal error: termcap.h: No such file or directory
+compilation terminated.
+```


### PR DESCRIPTION
Before:
![before SS](https://user-images.githubusercontent.com/6709544/33401392-6ddb5684-d559-11e7-95a1-12fc98d2ecfd.png)

After:
![after SS](https://user-images.githubusercontent.com/6709544/33401400-76cfa09c-d559-11e7-8c33-f6c0ea811345.png)
